### PR TITLE
第２回 シェルをカスタマイズしよう [b. コマンドの実行履歴をfzfで絞り込む】履歴番号を除去してfzfにパイプするように修正

### DIFF
--- a/202302/.bashrc
+++ b/202302/.bashrc
@@ -75,7 +75,7 @@ PROMPT_COMMAND='__git_ps1 "[\u@\h \t \w" "]\\\$ "'
 
 select-history() {
   # コマンドの実行履歴をfzfで選択肢、コマンドラインへ書き込む
-  READLINE_LINE="$(HISTTIMEFORMAT='' history | awk '{ print $2}'  | fzf --query "$READLINE_LINE")"
+  READLINE_LINE="$(HISTTIMEFORMAT='' history | awk '{ $1 = "";print}' | fzf --query "$READLINE_LINE")"
   # カーソルをコマンドラインの右端に移動
   READLINE_POINT=$#READLINE_LINE
 }


### PR DESCRIPTION
「最強の開発環境探求の道」を楽しく拝読させて頂いています。
非常に参考にさせて頂いています。

タイトル通りですが、「第２回 シェルをカスタマイズしよう 」のリスト４ 【bashの場合】コマンドの実行履歴をfzfで絞り込む設定を実施したところ、過去に実行したコマンドの先頭のみしかfzfで表示されませんでした。
本文の内容とリスト5 zshの場合を拝読して、期待する処理としてはhistoryの履歴番号を除去してオプションを含めた過去に実行したコマンドをfzfで表示するだと思います。
bashでこの処理が実現するように修正してみました。

### 試行環境情報
| 環境|バージョン|
|-----------|------------|
OS|Ubutu 22.04.2 LTS
bash|GNU bash 5.1.16

### 事象
リスト４ 【bashの場合】コマンドの実行履歴をfzfで絞り込む設定を実施すると、過去に実行したコマンドの先頭のみしかfzfで表示されない
ex)
```
$history
1  top
2  cd sample
3  sudo apt update
```
リスト４を.bashrcを記載後に[Ctrl+R]実行
```
top
cd
sudo
`````

### 期待する結果
リスト４を.bashrcを記載後に[Ctrl+R]実行
```
top
cd sample
sudo apt update
`````

### 修正内容
履歴番号を除去してfzfにパイプするように修正

